### PR TITLE
Fix pythonpath issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ test:
 
 run:
 	@echo "Running driver logic server ..."
-	PYTHONPATH=$(SRC_DIR):$$PYTHONPATH python rose/main.py --port $(PORT) --drivers $(DRIVERS)
+	python main.py --port $(PORT) --drivers $(DRIVERS)
 
 build-image:
 	@echo "Building container image ..."

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import argparse
 import asyncio
 import logging
+
 from rose.engine import server
 
 

--- a/rose/engine/score.py
+++ b/rose/engine/score.py
@@ -1,4 +1,5 @@
 """ Score logic """
+
 import logging
 
 from rose.engine import config


### PR DESCRIPTION
issue:
on windows setting PYTHONPATH from the CLI does not work

fix:
remove the need to change PYTHONPATH